### PR TITLE
feat: PainterNode ability to hide background in output

### DIFF
--- a/PainterNode/js/painter_node.js
+++ b/PainterNode/js/painter_node.js
@@ -643,12 +643,36 @@ class Painter {
     labelSaveImage.append(saveImageCheckbox);
     // end - Save image
 
+    // Hide Background in Output
+    const labelHideBackground = makeElement("label", {
+      textContent: "Hide Background in Output: ",
+      style: "font-size: 10px; display: block; text-align: right;",
+      title: "Hides the background layer in the final output image.",
+    });
+
+    const hideBackgroundCheckbox = makeElement("input", {
+      type: "checkbox",
+      class: ["hideBackground_checkbox"],
+      checked:
+        this.storageCls.settings_painter_node.settings?.hideBackground ?? false, // Default to false
+      onchange: (e) => {
+        const checked = !!e.target.checked;
+        this.storageCls.settings_painter_node.settings.hideBackground = checked;
+
+        this.saveSettingsPainterNode();
+      },
+    });
+
+    labelHideBackground.append(hideBackgroundCheckbox);
+    // end - Hide Background in Output
+
     settingsBox.append(
       makeElement("legend", {
         textContent: "Settings",
         style: "color: rgb(205, 202, 15);",
       }),
-      labelSaveImage
+      labelSaveImage,
+      labelHideBackground,
     );
 
     // end - Settings fieldset
@@ -2591,6 +2615,15 @@ class Painter {
       }
     }
 
+    if (this.storageCls.settings_painter_node.settings.hideBackground) {
+      if (this.canvas.backgroundImage) {
+        this.canvas.backgroundImage.set({
+          opacity: 0,
+        });
+        this.canvas.renderAll();
+      }
+    }
+
     this.canvasSaveSettingsPainter();
 
     await new Promise((res) => {
@@ -2633,6 +2666,13 @@ class Painter {
                 activeObj.visible = true;
                 activeObj.hasControls = true;
                 activeObj.hasBorders = false;
+              }
+            }
+            if (this.storageCls.settings_painter_node.settings.hideBackground) {
+              if (this.canvas.backgroundImage) {
+                this.canvas.backgroundImage.set({
+                  opacity: 1,
+                });
               }
             }
             this.canvas.renderAll();


### PR DESCRIPTION
Add a new option in the settings panel to hide image background when in the node's output image.

<img width="671" height="667" alt="image" src="https://github.com/user-attachments/assets/46c412bf-dcca-4b33-943c-1bb48cc0deb6" />

This mode makes it possible to draw overlay on the input image and output new elements only. It may be helpful in some workflows. For examlple, in my Flux Text model workflow, it can be used to place text on the image and output the "glyph" image as the model's required input.

<img width="3662" height="1965" alt="image" src="https://github.com/user-attachments/assets/471580b9-f213-4348-a71e-bd8243d957f3" />

The feature is implemented by hiding the background before exporting the canvas to png with `toBlob` and recover it after exporting. However, the canvas may flash while updating the output.