### PR TITLE
fix: PainterNode buffer is not large enough

### DIFF
--- a/PainterNode/painter_node.py
+++ b/PainterNode/painter_node.py
@@ -382,6 +382,9 @@ class PainterNode(object):
             input_images = []
 
             for imgs in images:
+                # Add alpha channel if not present
+                if imgs.shape[2] == 3:
+                    imgs = torch.cat([imgs, torch.ones((*imgs.shape[:2], 1))], dim=2)
                 i = 255.0 * imgs.cpu().numpy()
                 i = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8), mode="RGBA")
                 input_images.append(toBase64ImgUrl(i))


### PR DESCRIPTION
The `image` parameter may only have 3 channels. When piping an RGB image into the PainterNode, a ValueError of "buffer is not large enough" will be triggered.

<img width="3058" height="1417" alt="image" src="https://github.com/user-attachments/assets/e55902b6-dff7-4e15-b1c4-8691c5b6531f" />

The issue could be fixed by adding a dummy alpha channel if the alpha channel does not exist, before calling `Image.fromarray`.