### PR TITLE
fix for python3.13+

### DIFF
--- a/ArgosTranslateNode/requirements.txt
+++ b/ArgosTranslateNode/requirements.txt
@@ -1,1 +1,1 @@
-argostranslate
+git+https://github.com/argosopentech/argos-translate.git@08f017c324628434d671cf4d191ce681c620ff33


### PR DESCRIPTION
Currently the node is broken on python 3.13 (and thus on the latest comfyUI embedded)
 This is due to a dependency not being compatible. the dependency was updated but not yet published to pipy. This fixes it by pulling the fixed version directly from the repo on a fixed version. i tested it on python 3.11, 3.12 and 3.12 + 3.13 latest embedded comfyUI portable: works perfectly.

As soon as the new version is published the change can simply be reverted

this fixes https://github.com/AlekPet/ComfyUI_Custom_Nodes_AlekPet/issues/180

@AlekPet pls accept my humble offering